### PR TITLE
Add simulation distance flag, remove unnecessary comment

### DIFF
--- a/analysis_config/spigot.yml
+++ b/analysis_config/spigot.yml
@@ -92,3 +92,8 @@ max-entity-collisions:
   - parseInt(spigot["world-settings"]["default"]["max-entity-collisions"]) >= 8
   prefix: "❌"
   value: "Decrease this in spigot.yml.\nRecommended: 2."
+simulation-distance:
+- expressions:
+  - spigot["world-settings"]["default"]["simulation-distance"] == "default" or parseInt(spigot["world-settings"]["default"]["simulation-distance"]) > 5
+  prefix: "❌"
+  value: "Decrease this in spigot.yml.\nRecommended: 5 or lower."

--- a/functions/analyzeProfile.js
+++ b/functions/analyzeProfile.js
@@ -250,14 +250,7 @@ module.exports = async function analyzeProfile(message, client, args) {
 		}
 	});
 
-	// No way to get gamerules from spark
-	// const worlds = sampler.metadata.platformStatistics.world.worlds;
-	// let high_mec = false;
-	// worlds.forEach(world => {
-	// 	const max_entity_cramming = parseInt(world.gamerules.maxEntityCramming);
-	// 	if (max_entity_cramming >= 24) high_mec = true;
-	// });
-	// if (high_mec) fields.push({ name: '❌ maxEntityCramming', value: 'Decrease this by running the /gamerule command in each world. Recommended: 8.', inline: true });
+	// No way to get gamerules from spark. If this changes in the future, add a maxEntityCramming field. See analyzeTimings.js for example.
 
 	const tpstypes = sampler.metadata.platformStatistics.tps;
 	const avgtps = Math.min(Math.round((tpstypes.last1m + tpstypes.last5m + tpstypes.last15m) / 3), 20);


### PR DESCRIPTION
We previously had a no-tick-view-distance in 2022 but removed that. Not sure why we never replaced it with simulation-distance. Didn't look too closely. This PR adds simulation-distance with a recommendation of 5. Default is "default" or 10. Open to suggestions for what our rec should be.